### PR TITLE
feat: support of ESP32-S3 boards with 4MB of flash

### DIFF
--- a/.github/workflows/firmware-compile/action.yml
+++ b/.github/workflows/firmware-compile/action.yml
@@ -25,6 +25,9 @@ runs:
     - name: Install PlatformIO Core
       shell: bash
       run: pip install --upgrade platformio
+    - name: Update boards with the custom ones
+      shell: bash
+      run: cp ${{ inputs.project-folder }}/firmware/boards/*.json ~/.platformio/platforms/espressif32/boards/ || echo "Ok"
     - name: Build ${{ inputs.project-folder }}
       shell: bash
       run: pio run -d ${{ inputs.project-folder }} -e ${{ inputs.project-env }}

--- a/.github/workflows/firmware-compile/action.yml
+++ b/.github/workflows/firmware-compile/action.yml
@@ -27,7 +27,7 @@ runs:
       run: pip install --upgrade platformio
     - name: Update boards with the custom ones
       shell: bash
-      run: cp ${{ inputs.project-folder }}/firmware/boards/*.json ~/.platformio/platforms/espressif32/boards/ || echo "Ok"
+      run: cp ${{ inputs.project-folder }}/boards/*.json ~/.platformio/platforms/espressif32/boards/ || echo "Ok"
     - name: Build ${{ inputs.project-folder }}
       shell: bash
       run: pio run -d ${{ inputs.project-folder }} -e ${{ inputs.project-env }}

--- a/.github/workflows/firmware-compile/action.yml
+++ b/.github/workflows/firmware-compile/action.yml
@@ -25,7 +25,10 @@ runs:
     - name: Install PlatformIO Core
       shell: bash
       run: pip install --upgrade platformio
-    - name: Update boards with the custom ones
+    - name: Install PlatformIO Espressif32 platform
+      shell: bash
+      run: pio platform install espressif32@6.10.0
+    - name: Update boards with the custom Espressif32 ones
       shell: bash
       run: cp ${{ inputs.project-folder }}/boards/*.json ~/.platformio/platforms/espressif32/boards/ || echo "Ok"
     - name: Build ${{ inputs.project-folder }}

--- a/.github/workflows/firmware-compile/action.yml
+++ b/.github/workflows/firmware-compile/action.yml
@@ -27,7 +27,7 @@ runs:
       run: pip install --upgrade platformio
     - name: Install PlatformIO Espressif32 platform
       shell: bash
-      run: pio platform install espressif32@6.10.0
+      run: pio pkg install -d ${{ inputs.project-folder }}
     - name: Update boards with the custom Espressif32 ones
       shell: bash
       run: cp ${{ inputs.project-folder }}/boards/*.json ~/.platformio/platforms/espressif32/boards/ || echo "Ok"

--- a/firmware/boards/esp32-s3-4MB.json
+++ b/firmware/boards/esp32-s3-4MB.json
@@ -41,7 +41,7 @@
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 8388608,
+    "maximum_size": 4194304,
     "require_upload_port": true,
     "speed": 460800
   },

--- a/firmware/boards/esp32-s3-4MB.json
+++ b/firmware/boards/esp32-s3-4MB.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESP32-S3-SuperMini (4 MB Flash)",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.espboards.dev/esp32/esp32-s3-super-mini/",
+  "vendor": "Espressif"
+}

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = firmware_esp32s3
+default_envs = firmware
 
 [env:firmware]
 platform = espressif32@6.10.0

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = firmware
+default_envs = firmware_esp32s3
 
 [env:firmware]
 platform = espressif32@6.10.0
@@ -96,7 +96,7 @@ build_flags =
 
 [env:firmware_esp32s3]
 extends = env:firmware
-board = esp32-s3-devkitc-1
+board = esp32-s3-4MB
 
 [env:firmware_esp32c3]
 extends = env:firmware


### PR DESCRIPTION
Support ESP32-S3 with 4MB of flash with the custom board json file.

Resolves #357 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові функції**
  * Додано підтримку плати ESP32-S3-SuperMini з 4 МБ флеш-пам’яті.
  * Тепер можна використовувати власні визначення плат у процесі складання прошивки.

* **Зміни конфігурації**
  * Оточення для ESP32-S3 оновлено для використання нової плати ESP32-S3-4MB замість попередньої.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->