### PR TITLE
chore(dependency): bump espressif32 and FastLED

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = firmware
 
 [env:firmware]
-platform = espressif32@6.10.0
+platform = espressif32@6.11.0
 board = esp32dev
 build_src_flags =
 	'-D VERSION="4.5-b127"'
@@ -39,7 +39,7 @@ lib_deps =
 	mathieucarbou/ESPAsyncWebServer@3.3.18
 	wollewald/BH1750_WE@1.1.10
 	denyschuhlib/NTPtime@1.2.1
-	fastled/FastLED@3.9.15
+	fastled/FastLED@3.10.1
 	tzapu/WiFiManager@2.0.17
 	sensirion/arduino-sht@1.2.6
 	soylentorange/forcedBMX280@1.1.1


### PR DESCRIPTION
- espressif32 platform to 6.11.0 
    ref: https://github.com/platformio/platform-espressif32/releases/tag/v6.11.0

- FastLED library to 3.10.1 
     refs: 
       - https://github.com/FastLED/FastLED/releases/tag/3.10.1 
       - https://github.com/FastLED/FastLED/releases/tag/3.10.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Оновлення**
  * Оновлено платформу Espressif ESP32 до версії 6.11.0.
  * Оновлено бібліотеку FastLED до версії 3.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->