### PR TITLE
Potential fix for code scanning alert no. 148: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -7,6 +7,8 @@ on:
           required: true
           type: string
 run-name: Release BETA ${{ inputs.release-version }}-b${{ github.run_number }}
+permissions:
+  contents: read
 env:
   BETA_VERSION: ${{ inputs.release-version }}-b${{ github.run_number }}
   RELEASE_TITLE: Beta ${{ inputs.release-version }}-b${{ github.run_number }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,6 @@
   name: 🏗️ Compile Firmware
+  permissions:
+    contents: read
   on:
     pull_request:
       types: [ opened, synchronize, reopened ]

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -44,6 +44,8 @@ on:
         description: Web server 
 
 run-name: Deploy Microservices from '${{ github.ref_name }}' branch
+permissions:
+  contents: read
 jobs:
     pytests:
       uses: ./.github/workflows/pytests.yml

--- a/.github/workflows/deploy_update_server.yml
+++ b/.github/workflows/deploy_update_server.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
     
 run-name: Deploy Update Server from '${{ github.ref_name }}' branch
+permissions:
+  contents: read
 jobs:
     pytests:
       uses: ./.github/workflows/pytests.yml

--- a/.github/workflows/deploy_watchdog.yml
+++ b/.github/workflows/deploy_watchdog.yml
@@ -34,6 +34,7 @@ on:
         default: "watchdog.log"
 
 run-name: Deploy Watchdog from '${{ github.ref_name }}' branch
+permissions: {}
 jobs:
     deploy_websocket:
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy_websockets.yml
+++ b/.github/workflows/deploy_websockets.yml
@@ -39,6 +39,7 @@ on:
           - ERROR
 
 run-name: Deploy Websockets from '${{ github.ref_name }}' branch
+permissions: {}
 jobs:
     pytests:
       uses: ./.github/workflows/pytests.yml

--- a/.github/workflows/deploy_websockets_dev.yml
+++ b/.github/workflows/deploy_websockets_dev.yml
@@ -46,6 +46,9 @@ on:
           - CRITICAL
           - ERROR
 
+permissions:
+  contents: read
+
 run-name: Deploy Dev Websockets from '${{ github.ref_name }}' branch
 jobs:
     pytests:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - "flasher/**"
       - "deploy/**"
+permissions:
+  contents: read
 jobs:
   check_flasher:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - "deploy/**"
   workflow_call:
+permissions:
+  contents: read
 jobs:
   pytests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
           required: true
           type: string
 run-name: Release ${{ inputs.release-version }} (${{ inputs.release-title }})
+permissions:
+  contents: read
 jobs:
   build:
     if: ${{ github.ref_name == 'master' }}

--- a/.github/workflows/sync_wiki.yml
+++ b/.github/workflows/sync_wiki.yml
@@ -10,6 +10,9 @@ on:
     types: [docs]
   gollum:
 
+permissions:
+  contents: read
+
 env:
   GIT_AUTHOR_NAME: Actionbot
   GIT_AUTHOR_EMAIL: actions@github.com


### PR DESCRIPTION
Potential fix for [https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/148](https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/148)

Add an explicit top-level `permissions` block in `.github/workflows/deploy_websockets_dev.yml` so all jobs in this workflow default to least privilege unless overridden.  
Best minimal fix (without changing functionality): set:

- `contents: read`

This is the standard minimal baseline for many workflows and prevents unintended write scopes from inherited defaults.  
Change location: immediately after the `on:` inputs section (before `run-name` or `jobs`), at workflow root indentation.

No new imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Посилено безпеку: оновлено налаштування дозволів у автоматизованих процесах для обмеження доступу до системних ресурсів та підвищення контролю над дозволами токенів.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->