### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_nginx.yml
+++ b/.github/workflows/deploy_nginx.yml
@@ -2,6 +2,8 @@ name: 🌐 Deploy Nginx
 on:
   workflow_dispatch:
 
+permissions: {}
+
 run-name: Deploy Nginx from '${{ github.ref_name }}' branch
 jobs:
     deploy_nginx:


### PR DESCRIPTION
Potential fix for [https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/67](https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/67)

Add an explicit `permissions` block at the workflow root (best here, since there is one job) to limit `GITHUB_TOKEN` privileges.  
For this workflow, the safest non-breaking baseline is:

- `permissions: {}`

This disables all default token scopes, which should not change behavior because the job only uses repository secrets and SSH to a remote host. It does not rely on GitHub token-powered operations in the shown steps.

**Where to change:** `.github/workflows/deploy_nginx.yml`, immediately after the trigger block (`on:` / `workflow_dispatch:`) and before `run-name:`.

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
