### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clone_count.yml
+++ b/.github/workflows/clone_count.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 */1 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/64](https://github.com/J-A-A-M/ukraine_alarm_map/security/code-scanning/64)

Add an explicit `permissions` block at the workflow root so all jobs inherit it.  
For this workflow, `contents: read` is the minimal safe baseline requested by the rule and does not alter existing functionality that relies on `secrets.SECRET_TOKEN` for authenticated writes.

**Best single fix:** in `.github/workflows/clone_count.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the workflow triggers (`on:` block) and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Оновлення версії

* **Внутрішні оновлення**
  * Оновлено конфігурацію робочого процесу.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->