### PR TITLE
feat: migrate flasher to Docker, add wiki/flasher nginx server blocks

### DIFF
--- a/.github/workflows/deploy_flasher.yml
+++ b/.github/workflows/deploy_flasher.yml
@@ -1,19 +1,54 @@
 name: ⚡ Deploy Flasher
-on: workflow_dispatch
+
+on:
+  push:
+    branches: [master, develop]
+    paths:
+      - 'flasher/**'
+      - 'deploy/flasher/**'
+      - 'deploy/redeploy_flasher.sh'
+      - '.github/workflows/deploy_flasher.yml'
+  workflow_dispatch:
+    inputs:
+      server_choice:
+        type: choice
+        default: 'Server 1'
+        description: Choose server
+        options:
+          - 'Server 1'
+          - 'Server 2'
+
+run-name: Deploy Flasher from '${{ github.ref_name }}' branch
+
 permissions:
   contents: read
+
 jobs:
-  deploy_flasher:
+  deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
+    env:
+      SERVER_IP: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_IP || secrets.CLOUD_SERVER_IP }}
+      SERVER_USER: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_USER || secrets.CLOUD_SERVER_USER }}
+      SERVER_SSH_KEY: ${{ inputs.server_choice == 'Server 2' && secrets.CLOUD_SERVER_2_SSH_KEY || secrets.CLOUD_SERVER_SSH_KEY }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Upload flasher to Github Pages
-      uses: ./.github/workflows/upload-pages
-    
+      - name: Deploy Flasher
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ env.SERVER_IP }}
+          username: ${{ env.SERVER_USER }}
+          key: ${{ env.SERVER_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            TEMP_DIR=$(mktemp -d)
+            trap 'rm -rf "$TEMP_DIR"' EXIT
+            cd "$TEMP_DIR"
+            git clone --branch ${{ github.ref_name }} https://github.com/${{ github.repository }}.git .
+            bash deploy/redeploy_flasher.sh
+      - name: Clear unused images
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ env.SERVER_IP }}
+          username: ${{ env.SERVER_USER }}
+          key: ${{ env.SERVER_SSH_KEY }}
+          script: |
+            docker image prune -f

--- a/deploy/flasher/Dockerfile
+++ b/deploy/flasher/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY flasher/ /usr/share/nginx/html

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -110,6 +110,118 @@ http {
         }
     }
 
+    # JAAM Wiki
+    server {
+        listen 80;
+        server_name info.jaam.net.ua;
+
+        # Block clients without CF-Connecting-IP header
+        if ($http_cf_connecting_ip = "") {
+            return 403;
+        }
+
+        location / {
+            proxy_pass http://jaam_wiki:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # JAAM Wiki secure
+    server {
+        listen 443 ssl;
+        http2   on;
+        server_name info.jaam.net.ua;
+
+        # Block clients without CF-Connecting-IP header
+        if ($http_cf_connecting_ip = "") {
+            return 403;
+        }
+
+        # SSL certificates (provided by Cloudflare Origin CA)
+        ssl_certificate /etc/nginx/ssl/cloudflare.crt;
+        ssl_certificate_key /etc/nginx/ssl/cloudflare.key;
+
+        ssl_trusted_certificate /etc/nginx/ssl/cloudflare_intermediate.crt;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384';
+        ssl_prefer_server_ciphers on;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-XSS-Protection "1; mode=block";
+
+        location / {
+            proxy_pass http://jaam_wiki:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # JAAM Flasher
+    server {
+        listen 80;
+        server_name flasher.jaam.net.ua;
+
+        # Block clients without CF-Connecting-IP header
+        if ($http_cf_connecting_ip = "") {
+            return 403;
+        }
+
+        location / {
+            proxy_pass http://jaam_flasher:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # JAAM Flasher secure
+    server {
+        listen 443 ssl;
+        http2   on;
+        server_name flasher.jaam.net.ua;
+
+        # Block clients without CF-Connecting-IP header
+        if ($http_cf_connecting_ip = "") {
+            return 403;
+        }
+
+        # SSL certificates (provided by Cloudflare Origin CA)
+        ssl_certificate /etc/nginx/ssl/cloudflare.crt;
+        ssl_certificate_key /etc/nginx/ssl/cloudflare.key;
+
+        ssl_trusted_certificate /etc/nginx/ssl/cloudflare_intermediate.crt;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384';
+        ssl_prefer_server_ciphers on;
+
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-XSS-Protection "1; mode=block";
+
+        location / {
+            proxy_pass http://jaam_flasher:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
     # Firmware update server
     server {
         listen 2095;

--- a/deploy/redeploy_flasher.sh
+++ b/deploy/redeploy_flasher.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "JAAM FLASHER"
+
+# Build Docker image
+echo "Building Docker image..."
+docker build -t jaam_flasher -f deploy/flasher/Dockerfile .
+
+# Stop and remove old container
+echo "Stopping old container..."
+docker stop jaam_flasher || true
+docker rm jaam_flasher || true
+
+# Deploy new container
+echo "Deploying new container..."
+docker run --name jaam_flasher \
+    --restart unless-stopped \
+    --network=jaam \
+    -d \
+    jaam_flasher
+
+echo "Container deployed successfully!"


### PR DESCRIPTION
## Summary

- Migrate flasher from GitHub Pages to Docker container on server (same pattern as wiki)
- Add `deploy/flasher/Dockerfile` — nginx:alpine serving `flasher/` static files
- Add `deploy/redeploy_flasher.sh` — docker build + run on `jaam` network
- Update `deploy_flasher.yml` — SSH deploy via appleboy/ssh-action, push trigger on `flasher/**` paths, Server 1/2 choice input
- Add nginx server blocks for `info.jaam.net.ua` → `jaam_wiki:80` (HTTP + HTTPS)
- Add nginx server blocks for `flasher.jaam.net.ua` → `jaam_flasher:80` (HTTP + HTTPS)

## Test plan

- [ ] Merge PR, run `deploy_flasher.yml` via workflow_dispatch → container `jaam_flasher` starts on server
- [ ] Run `deploy_nginx.yml` → nginx picks up new server blocks
- [ ] `flasher.jaam.net.ua` serves flasher, `info.jaam.net.ua` serves wiki